### PR TITLE
Removed the travis-ci build status label (#407)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-raft [![Build Status](https://travis-ci.org/hashicorp/raft.png)](https://travis-ci.org/hashicorp/raft) [![CircleCI](https://circleci.com/gh/hashicorp/raft.svg?style=svg)](https://circleci.com/gh/hashicorp/raft)
+raft [![CircleCI](https://circleci.com/gh/hashicorp/raft.svg?style=svg)](https://circleci.com/gh/hashicorp/raft)
 ====
 
 raft is a [Go](http://www.golang.org) library that manages a replicated


### PR DESCRIPTION
Signed-off-by: Alwin Doss <alwindoss84@gmail.com>